### PR TITLE
region: guests: sshable: more friendly fail reason for proxy_forward

### DIFF
--- a/pkg/compute/models/guest_sshable.go
+++ b/pkg/compute/models/guest_sshable.go
@@ -30,6 +30,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	cloudproxy_module "yunion.io/x/onecloud/pkg/mcclient/modules/cloudproxy"
+	"yunion.io/x/onecloud/pkg/util/httputils"
 	ssh_util "yunion.io/x/onecloud/pkg/util/ssh"
 )
 
@@ -173,9 +174,15 @@ func (guest *SGuest) GetDetailsSshable(
 				}
 			}
 		} else {
+			var reason string
+			if jce, ok := err.(*httputils.JSONClientError); ok {
+				reason = jce.Details
+			} else {
+				reason = err.Error()
+			}
 			tryData.AddMethodTried(compute_api.GuestSshableMethodData{
 				Method: compute_api.MethodProxyForward,
-				Reason: err.Error(),
+				Reason: reason,
 			})
 		}
 	}

--- a/pkg/compute/models/guest_sshable.go
+++ b/pkg/compute/models/guest_sshable.go
@@ -298,6 +298,7 @@ func (guest *SGuest) sshableTry(
 	if client, err := conf.ConnectContext(ctx); err == nil {
 		defer client.Close()
 		methodData.Sshable = true
+		ok = true
 	} else {
 		methodData.Reason = err.Error()
 	}

--- a/pkg/compute/models/guest_sshable.go
+++ b/pkg/compute/models/guest_sshable.go
@@ -72,6 +72,10 @@ func (guest *SGuest) GetDetailsSshable(
 	userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject,
 ) (jsonutils.JSONObject, error) {
+	if guest.Status != compute_api.VM_RUNNING {
+		return nil, httperrors.NewBadRequestError("server sshable state can only be checked when in running state")
+	}
+
 	tryData := &GuestSshableTryData{
 		User: "cloudroot",
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
region: guests: sshable: more friendly fail reason for proxy_forward
region: guests: sshable: return early on sshable=true
region: guests: sshable: only check sshable state when in running state
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.7

/area region
/cc @tb365 
/cc @zexi 
/cc @swordqiu 