### PR TITLE
Automated cherry pick of #10678: fix(host): detect ovs version

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -714,7 +714,7 @@ func (h *SHostInfo) detectOvsKOVersion() error {
 	lines := strings.Split(string(output), "\n")
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
-		if strings.HasPrefix(line, "version:") || (h.IsAarch64() && strings.HasPrefix(line, "vermagic")) {
+		if strings.HasPrefix(line, "version:") || strings.HasPrefix(line, "vermagic") {
 			log.Infof("kernel module openvswitch %s", line)
 			return nil
 		}


### PR DESCRIPTION
Cherry pick of #10678 on release/3.6.

#10678: fix(host): detect ovs version