### PR TITLE
Automated cherry pick of #10692: fix(readme): rename OneCloud to YunionCloud

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,12 +1,12 @@
-# Yunion OneCloud (云联融合云）
+# Yunion Cloud (云联融合云）
 
-[![CircleCI](https://circleci.com/gh/yunionio/onecloud.svg?style=svg)](https://circleci.com/gh/yunionio/onecloud) 
-[![Build Status](https://travis-ci.com/yunionio/onecloud.svg?branch=master)](https://travis-ci.org/yunionio/onecloud) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/yunionio/onecloud)](https://goreportcard.com/report/github.com/yunionio/onecloud) 
+[![CircleCI](https://circleci.com/gh/yunionio/yunioncloud.svg?style=svg)](https://circleci.com/gh/yunionio/yunioncloud) 
+[![Build Status](https://travis-ci.com/yunionio/yunioncloud.svg?branch=master)](https://travis-ci.org/yunionio/yunioncloud) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/yunionio/yunioncloud)](https://goreportcard.com/report/github.com/yunionio/yunioncloud) 
 
 ## 什么是云联融合云?
 
-云联融合云（Yunion OneCloud）是一个开源的多云平台。融合云构建在用户分布于多云基础设施之上，通过技术手段将分布于多云的异构IT资源统一管理，将多底层多云的差异向用户屏蔽，并通过网络和调度实现资源的融合与打通，在多云之上进行抽象，向用户呈现统一的使用界面和API接口，让用户就像使用一个云平台一样使用分布于多云的资源，实现一个统一的“云上之云”的云平台。
+云联融合云（Yunion Cloud）是一个开源的多云平台。融合云构建在用户分布于多云基础设施之上，通过技术手段将分布于多云的异构IT资源统一管理，将多底层多云的差异向用户屏蔽，并通过网络和调度实现资源的融合与打通，在多云之上进行抽象，向用户呈现统一的使用界面和API接口，让用户就像使用一个云平台一样使用分布于多云的资源，实现一个统一的“云上之云”的云平台。
 
 鉴于企业IT基础设施的两个趋势：1. 企业使用多云基础设施，并且公有云是最主要的基础设施提供者；2. 企业应用将逐步云原生化，企业IT基础设施需要为Kubernetes优化。融合云为此架构而设计。一方面抽象管理底层的多云基础设施，另一方面为多云Kubernetes提供运行环境。融合云为企业未来的的IT基础设施架构而设计。
 
@@ -18,18 +18,18 @@
 
 - 内置私有云
 
-  OneCloud内置完备的私有云实现，提供对用户本地IDC的虚拟机、物理机和负载均衡等资源管理。
+  YunionCloud 内置完备的私有云实现，提供对用户本地IDC的虚拟机、物理机和负载均衡等资源管理。
 
 - 为多云Kubernetes提供运行环境
 
-  OneCloud自身为运行在Kubernetes的云原生应用，并且能在多云环境部署运行Kubernetes集群。
+  YunionCloud 自身为运行在Kubernetes的云原生应用，并且能在多云环境部署运行Kubernetes集群。
 
 欢迎安装部署云联融合云，期待大家的反馈！
 
 
 ## 部署
 
-请参考文档 [安装部署](https://docs.yunion.io/docs/setup/) 搭建 OneCloud 集群。
+请参考文档 [安装部署](https://docs.yunion.io/docs/setup/) 搭建 YunionCloud 集群。
 
 
 ## 文档
@@ -51,4 +51,4 @@
 
 ## License
 
-OneCloud 使用 Apache license 2.0. 详情请看 [LICENSE](./LICENSE) 。
+YunionCloud 使用 Apache license 2.0. 详情请看 [LICENSE](./LICENSE) 。

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Yunion OneCloud
+# Yunion Cloud
 
-[![CircleCI](https://circleci.com/gh/yunionio/onecloud.svg?style=svg)](https://circleci.com/gh/yunionio/onecloud) 
-[![Build Status](https://travis-ci.com/yunionio/onecloud.svg?branch=master)](https://travis-ci.com/yunionio/onecloud/branches) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/yunionio/onecloud)](https://goreportcard.com/report/github.com/yunionio/onecloud) 
+[![CircleCI](https://circleci.com/gh/yunionio/yunioncloud.svg?style=svg)](https://circleci.com/gh/yunionio/yunioncloud) 
+[![Build Status](https://travis-ci.com/yunionio/yunioncloud.svg?branch=master)](https://travis-ci.com/yunionio/yunioncloud/branches) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/yunionio/yunioncloud)](https://goreportcard.com/report/github.com/yunionio/yunioncloud) 
 
 ### [README in Chinese](./README-CN.md)
 
-## What is Yunion OneCloud?
+## What is Yunion Cloud?
 
-Yunion OneCloud is an open source unified-IaaS cloud platform.
+Yunion Cloud is an open source unified-IaaS cloud platform.
 
-As its name sugguests, 'Yun' means 'cloud' in Chinese and 'Yunion OneCloud' means to unify many distinct clouds into the one that behaves like an integral cloud platform.
+As its name sugguests, 'Yun' means 'cloud' in Chinese and 'Yunion Cloud' means to unify many distinct clouds into the one that behaves like an integral cloud platform.
 
-As trends show, the enterprise IT infrastructure in the future would be unavoidably heterogeneous and the public clouds should be the major infrastructure providers for many enterprises. Further, the infrastructure would most likely be prepared for the cloud-native applications running on Kubernetes. Yunion OneCloud is built to provide the cloud architecture for this scenario such that it is the middle layer between the underlying cloud infrustructures and the overlay kubernetes clusters across many clouds.
+As trends show, the enterprise IT infrastructure in the future would be unavoidably heterogeneous and the public clouds should be the major infrastructure providers for many enterprises. Further, the infrastructure would most likely be prepared for the cloud-native applications running on Kubernetes. Yunion Cloud is built to provide the cloud architecture for this scenario such that it is the middle layer between the underlying cloud infrustructures and the overlay kubernetes clusters across many clouds.
 
-Many may consider Yunion OneCloud as a multi-cloud management platform (MCMP). Rather, we would view it as an IaaS platform as it does not only manage the resources and services from many clouds, but also hides the differences of underlying technologies and exposes one set of APIs that allow programatically interacting with the compute/storage/networking resources across many clouds.
+Many may consider Yunion Cloud as a multi-cloud management platform (MCMP). Rather, we would view it as an IaaS platform as it does not only manage the resources and services from many clouds, but also hides the differences of underlying technologies and exposes one set of APIs that allow programatically interacting with the compute/storage/networking resources across many clouds.
 
-Yunion OneCloud is working on abstracting APIs for the following resources:
+Yunion Cloud is working on abstracting APIs for the following resources:
 
 * Compute, including virtual machines, images, etc.
 * Storage, including disks, snapshots, object storages, etc.
@@ -30,7 +30,7 @@ over the following many cloud providers:
 * Private clouds, including OpenStack, etc.
 * Public clouds, including Aliyun, AWS, Azure, Tencent Cloud, Huawei Cloud, etc.
 
-You are welcome to install and try Yunion OneCloud. Looking forward to your feedback.
+You are welcome to install and try Yunion Cloud. Looking forward to your feedback.
 
 ## Installation
 
@@ -38,7 +38,7 @@ Please refers to [install & deployment](https://docs.yunion.io/docs/setup/) (cur
 
 ## Documentations
 
-- [Yunion OneCloud Documents](https://docs.yunion.io/)
+- [Yunion Cloud Documents](https://docs.yunion.io/)
 
 - [Swagger API](https://docs.yunion.cn/apiv2/)
 


### PR DESCRIPTION
Cherry pick of #10692 on release/3.6.

#10692: fix(readme): rename OneCloud to YunionCloud