### PR TITLE
Automated cherry pick of #10705: fix(cloudcommon): use rbac authentication dedicated to the list interface in GetModelProperty

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -932,11 +932,7 @@ func (dispatcher *DBModelDispatcher) tryGetModelProperty(ctx context.Context, pr
 	}
 
 	if consts.IsRbacEnabled() {
-		ownerId, err := fetchOwnerId(ctx, dispatcher.modelManager, userCred, query)
-		if err != nil {
-			return nil, httperrors.NewGeneralError(err)
-		}
-		err = isClassRbacAllowed(dispatcher.modelManager, userCred, ownerId, policy.PolicyActionList, property)
+		_, _, err := FetchCheckQueryOwnerScope(ctx, userCred, query, dispatcher.modelManager, policy.PolicyActionList, true)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry pick of #10705 on release/3.6.

#10705: fix(cloudcommon): use rbac authentication dedicated to the list interface in GetModelProperty