### PR TITLE
Automated cherry pick of #10729: fix(esxi): correctly set the imagePath outside the if block

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -810,7 +810,8 @@ func (self *SHost) addDisks(ctx context.Context, dc *SDatacenter, ds *SDatastore
 				size = 30 * 1024
 			}
 		} else {
-			imagePath, err := self.FileUrlPathToDsPath(imagePath)
+			var err error
+			imagePath, err = self.FileUrlPathToDsPath(imagePath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
 			}


### PR DESCRIPTION
Cherry pick of #10729 on release/3.6.

#10729: fix(esxi): correctly set the imagePath outside the if block