### PR TITLE
Automated cherry pick of #10750: vpcagent: ovn: fix port match condition formation

### DIFF
--- a/pkg/vpcagent/ovn/secgrouprules_acl.go
+++ b/pkg/vpcagent/ovn/secgrouprules_acl.go
@@ -121,7 +121,11 @@ func ruleToAcl(lport string, rule *agentmodels.SecurityGroupRule) (*ovn_nb.ACL, 
 
 		matches = append(matches, l4proto)
 		if len(portMatches) > 0 {
-			matches = append(matches, strings.Join(portMatches, " || "))
+			portMatch := strings.Join(portMatches, " || ")
+			if len(portMatches) > 1 {
+				portMatch = "( " + portMatch + " )"
+			}
+			matches = append(matches, portMatch)
 		}
 	}
 	switch rule.Protocol {


### PR DESCRIPTION
Cherry pick of #10750 on release/3.6.

#10750: vpcagent: ovn: fix port match condition formation