### PR TITLE
Automated cherry pick of #10761: fix(region): Remind that cloud account synchronization failed due to network synchronization failure

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2842,6 +2842,9 @@ func (cd *SCloudaccount) GetHost2Wire(ctx context.Context, userCred mcclient.Tok
 		return cd.vmwareHostWireCache, nil
 	}
 	hwJson := cd.GetMetadataJson(METADATA_EXT_HOST2WIRE_KEY, userCred)
+	if hwJson == nil {
+		return nil, fmt.Errorf("The cloud account synchronization network may have failed, please check the operation log first and solve the synchronization network problem")
+	}
 	ret := make(map[string][]SVs2Wire)
 	err := hwJson.Unmarshal(&ret)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #10761 on release/3.7.

#10761: fix(region): Remind that cloud account synchronization failed due to network synchronization failure