### PR TITLE
Automated cherry pick of #10810: fix(multicloud): set isEmulated as false for ecloud vpc

### DIFF
--- a/pkg/multicloud/ecloud/vpc.go
+++ b/pkg/multicloud/ecloud/vpc.go
@@ -79,7 +79,7 @@ func (v *SVpc) Refresh() error {
 }
 
 func (v *SVpc) IsEmulated() bool {
-	return true
+	return false
 }
 
 func (v *SVpc) GetRegion() cloudprovider.ICloudRegion {


### PR DESCRIPTION
Cherry pick of #10810 on release/3.7.

#10810: fix(multicloud): set isEmulated as false for ecloud vpc