### PR TITLE
Automated cherry pick of #10851: fix(region): avoid using LocalTaskWorker in time-consuming synchronization of cloudaccount

### DIFF
--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -94,25 +94,17 @@ func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoComplete(ctx co
 	syncRange := self.GetSyncRange()
 
 	db.OpsLog.LogEvent(provider, db.ACT_SYNCING_HOST, "", self.UserCred)
-	self.SetStage("OnSyncCloudProviderInfoComplete", nil)
 
-	taskman.LocalTaskRun(self, func() (jsonutils.JSONObject, error) {
-		provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
-		provider.SyncCallSyncCloudproviderInterVpcNetwork(ctx, self.UserCred)
-		return nil, nil
-	})
+	provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
+	provider.SyncCallSyncCloudproviderInterVpcNetwork(ctx, self.UserCred)
+
+	provider.CleanSchedCache()
+	self.SetStageComplete(ctx, nil)
+	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
+	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
 }
 
 func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoCompleteFailed(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	log.Errorf("faild to sync provider quotas %s", body.String())
 	self.OnSyncCloudProviderPreInfoComplete(ctx, obj, body)
-}
-
-func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderInfoComplete(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
-	provider := obj.(*models.SCloudprovider)
-	// provider.MarkEndSync(self.UserCred)
-	provider.CleanSchedCache()
-	self.SetStageComplete(ctx, nil)
-	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
-	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
 }


### PR DESCRIPTION
Cherry pick of #10851 on release/3.7.

#10851: fix(region): avoid using LocalTaskWorker in time-consuming synchronization of cloudaccount