### PR TITLE
fix(baremetal): baremetal ipmi probe reset link up state

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -1690,7 +1690,9 @@ func (b *SBaremetalInstance) SendNicInfo(nic *types.SNicDevInfo, idx int, nicTyp
 		params.Add(jsonutils.NewString(nicType), "nic_type")
 	}
 	params.Add(jsonutils.NewInt(int64(nic.Mtu)), "mtu")
-	params.Add(jsonutils.NewBool(nic.Up), "link_up")
+	if nic.Up != nil {
+		params.Add(jsonutils.NewBool(*nic.Up), "link_up")
+	}
 	if reset {
 		params.Add(jsonutils.JSONTrue, "reset")
 	}

--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -190,7 +190,6 @@ func (task *sBaremetalPrepareTask) configIPMISetting(cli *ssh.Client, i *baremet
 
 		ipmiNic := &types.SNicDevInfo{
 			Mac:   conf.Mac,
-			Up:    false,
 			Speed: 100,
 			Mtu:   1500,
 		}
@@ -441,7 +440,7 @@ func (task *sBaremetalPrepareTask) updateBmInfo(cli *ssh.Client, i *baremetalPre
 	}
 	if o.Options.EnablePxeBoot && task.baremetal.EnablePxeBoot() {
 		for _, nicInfo := range i.nicsInfo {
-			if nicInfo.Mac.String() != adminNic.GetMac().String() && nicInfo.Up {
+			if nicInfo.Mac.String() != adminNic.GetMac().String() && nicInfo.Up != nil && *nicInfo.Up {
 				err = task.doNicWireProbe(cli, nicInfo)
 				if err != nil {
 					// ignore the error

--- a/pkg/baremetal/tasks/bm_register.go
+++ b/pkg/baremetal/tasks/bm_register.go
@@ -245,8 +245,9 @@ func (s *sBaremetalRegisterTask) updateIpmiInfo(cli *ssh.Client) {
 			ipmitool.SetDellIPMILanPortShared(ipmiTool)
 		}
 	}
+	up := true
 	var nic = &types.SNicDevInfo{
-		Up:    true,
+		Up:    &up,
 		Speed: 100,
 		Mtu:   1500,
 	}

--- a/pkg/baremetal/tasks/ipmiprobe.go
+++ b/pkg/baremetal/tasks/ipmiprobe.go
@@ -157,9 +157,10 @@ func (self *SBaremetalIpmiProbeTask) sendIpmiNicInfo(lanConf *types.SIPMILanConf
 	if speed <= 0 {
 		speed = 100
 	}
+	up := true
 	ipmiNic := &types.SNicDevInfo{
 		Mac:   lanConf.Mac,
-		Up:    true,
+		Up:    &up,
 		Speed: speed,
 		Mtu:   1500,
 	}

--- a/pkg/cloudcommon/types/types.go
+++ b/pkg/cloudcommon/types/types.go
@@ -93,7 +93,7 @@ type SNicDevInfo struct {
 	Dev   string           `json:"dev"`
 	Mac   net.HardwareAddr `json:"mac"`
 	Speed int              `json:"speed"`
-	Up    bool             `json:"up"`
+	Up    *bool            `json:"up"`
 	Mtu   int              `json:"mtu"`
 }
 

--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -195,7 +195,7 @@ func ParseNicInfo(lines []string) []*types.SNicDevInfo {
 				Dev:   dev,
 				Mac:   mac,
 				Speed: speed,
-				Up:    up,
+				Up:    &up,
 				Mtu:   mtu,
 			})
 		}

--- a/pkg/util/sysutils/sysutils_test.go
+++ b/pkg/util/sysutils/sysutils_test.go
@@ -241,6 +241,8 @@ func TestParseNicInfo(t *testing.T) {
 	type args struct {
 		lines []string
 	}
+	up := true
+	down := false
 	mac1Str := "00:22:25:0b:ab:49"
 	mac2Str := "00:22:25:0b:ab:50"
 	mac1, _ := net.ParseMAC(mac1Str)
@@ -259,8 +261,8 @@ func TestParseNicInfo(t *testing.T) {
 				},
 			},
 			want: []*types.SNicDevInfo{
-				{Dev: "eth0", Mac: mac1, Speed: 0, Up: true, Mtu: 1500},
-				{Dev: "eth1", Mac: mac2, Speed: 0, Up: false, Mtu: 1500},
+				{Dev: "eth0", Mac: mac1, Speed: 0, Up: &up, Mtu: 1500},
+				{Dev: "eth1", Mac: mac2, Speed: 0, Up: &down, Mtu: 1500},
 			},
 		},
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: baremetal ipmi probe will reset link up state of every nic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area baremetal-agent
/cc @zexi 