### PR TITLE
Automated cherry pick of #10863: fix(region): make cloudprovider sync worker configurable

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -123,6 +123,7 @@ type ComputeOptions struct {
 	MinimalIpAddrReusedIntervalSeconds int `help:"Minimal seconds when a release IP address can be reallocate" default:"30"`
 
 	CloudSyncWorkerCount         int `help:"how many current synchronization threads" default:"5"`
+	CloudProviderSyncWorkerCount int `help:"how many current providers synchronize their regions, practically no limit" default:"10"`
 	CloudAutoSyncIntervalSeconds int `help:"frequency to check auto sync tasks" default:"30"`
 	DefaultSyncIntervalSeconds   int `help:"minimal synchronization interval, default 15 minutes" default:"900"`
 	MinimalSyncIntervalSeconds   int `help:"minimal synchronization interval, default 30 minutes" default:"1800"`

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -41,7 +41,7 @@ import (
 	_ "yunion.io/x/onecloud/pkg/compute/policy"
 	_ "yunion.io/x/onecloud/pkg/compute/regiondrivers"
 	_ "yunion.io/x/onecloud/pkg/compute/storagedrivers"
-	_ "yunion.io/x/onecloud/pkg/compute/tasks"
+	"yunion.io/x/onecloud/pkg/compute/tasks"
 	"yunion.io/x/onecloud/pkg/controller/autoscaling"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/multicloud/esxi"
@@ -86,6 +86,7 @@ func StartService() {
 	setInfluxdbRetentionPolicy()
 
 	models.InitSyncWorkers(options.Options.CloudSyncWorkerCount)
+	tasks.InitCloudproviderSyncWorkers(options.Options.CloudProviderSyncWorkerCount)
 
 	var (
 		electObj        *elect.Elect

--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -34,8 +34,8 @@ type CloudProviderSyncInfoTask struct {
 	taskman.STask
 }
 
-func init() {
-	syncWorker := appsrv.NewWorkerManager("CloudProviderSyncInfoTaskWorkerManager", 2, 512, true)
+func InitCloudproviderSyncWorkers(count int) {
+	syncWorker := appsrv.NewWorkerManager("CloudProviderSyncInfoTaskWorkerManager", count, 512, true)
 	taskman.RegisterTaskAndWorker(CloudProviderSyncInfoTask{}, syncWorker)
 }
 


### PR DESCRIPTION
Cherry pick of #10863 on release/3.5.

#10863: fix(region): make cloudprovider sync worker configurable