### PR TITLE
Automated cherry pick of #10876: fix(glance): image can't removed when size is 0

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1171,8 +1171,11 @@ func (self *SImage) Remove() error {
 	for i := 0; i < len(subimgs); i += 1 {
 		err := subimgs[i].RemoveFiles()
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "remove subimg %s", subimgs[i].GetName())
 		}
+	}
+	if self.Location == "" {
+		return nil
 	}
 	if strings.HasPrefix(self.Location, LocalFilePrefix) {
 		return self.RemoveFile()


### PR DESCRIPTION
Cherry pick of #10876 on release/3.7.

#10876: fix(glance): image can't removed when size is 0