### PR TITLE
Automated cherry pick of #10897: fix(region): make SScheduledTaskLabel implement IJointModelManager

### DIFF
--- a/pkg/compute/models/scheduledtask_label.go
+++ b/pkg/compute/models/scheduledtask_label.go
@@ -48,6 +48,14 @@ type SScheduledTaskLabel struct {
 	Label           string `width:"64" charset:"utf8" nullable:"false" index:"true"`
 }
 
+func (slm *SScheduledTaskLabelManager) GetMasterFieldName() string {
+	return "scheduled_task_id"
+}
+
+func (slm *SScheduledTaskLabelManager) GetSlaveFieldName() string {
+	return "label"
+}
+
 func (slm *SScheduledTaskLabelManager) Attach(ctx context.Context, taskId, label string) error {
 	sl := &SScheduledTaskLabel{
 		ScheduledTaskId: taskId,


### PR DESCRIPTION
Cherry pick of #10897 on release/3.5.

#10897: fix(region): make SScheduledTaskLabel implement IJointModelManager