### PR TITLE
cloudproxy: proxy_endpoints: create-from-server: allow name as arg

### DIFF
--- a/pkg/apis/cloudproxy/proxy_endpoints.go
+++ b/pkg/apis/cloudproxy/proxy_endpoints.go
@@ -30,6 +30,8 @@ type ProxyEndpointCreateInput struct {
 }
 
 type ProxyEndpointCreateFromServerInput struct {
+	Name string
+
 	ServerId string
 }
 

--- a/pkg/cloudproxy/models/proxy_endpoints.go
+++ b/pkg/cloudproxy/models/proxy_endpoints.go
@@ -93,6 +93,14 @@ func (man *SProxyEndpointManager) PerformCreateFromServer(ctx context.Context, u
 		return nil, httperrors.NewBadRequestError("cannot find ssh host ip address for this server")
 	}
 
+	name := input.Name
+	if name == "" {
+		name = serverInfo.Server.Name
+	}
+	if err := db.NewNameValidator(man, userCred, name, nil); err != nil {
+		return nil, httperrors.NewGeneralError(err)
+	}
+
 	proxyendpoint := &SProxyEndpoint{
 		User:       "cloudroot",
 		Host:       host,
@@ -101,7 +109,7 @@ func (man *SProxyEndpointManager) PerformCreateFromServer(ctx context.Context, u
 
 		IntranetIpAddr: nic.IpAddr,
 	}
-	proxyendpoint.Name = serverInfo.Server.Name
+	proxyendpoint.Name = name
 	proxyendpoint.DomainId = userCred.GetProjectDomainId()
 	proxyendpoint.ProjectId = userCred.GetProjectId()
 	if err := man.TableSpec().Insert(ctx, proxyendpoint); err != nil {

--- a/pkg/mcclient/options/cloudproxy/proxy_endpoints.go
+++ b/pkg/mcclient/options/cloudproxy/proxy_endpoints.go
@@ -49,6 +49,8 @@ func (opts *ProxyEndpointCreateOptions) Params() (jsonutils.JSONObject, error) {
 }
 
 type ProxyEndpointCreateFromServerOptions struct {
+	Name string
+
 	ServerId string `required:"true"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
cloudproxy: proxy_endpoints: create-from-server: allow name as arg
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.7

/area cloudproxy
/cc @tb365 
/cc @zexi 
