### PR TITLE
fix(region): use special localtask to run time-consuming provider synchronization task

### DIFF
--- a/pkg/cloudcommon/db/taskman/localtaskworker.go
+++ b/pkg/cloudcommon/db/taskman/localtaskworker.go
@@ -37,8 +37,8 @@ func Error2TaskData(err error) jsonutils.JSONObject {
 	return errJson
 }
 
-func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
-	localTaskWorkerMan.Run(func() {
+func LocalTaskRunWithWorkers(task ITask, proc func() (jsonutils.JSONObject, error), wm *appsrv.SWorkerManager) {
+	wm.Run(func() {
 
 		log.Debugf("XXXXXXXXXXXXXXXXXXLOCAL TASK RUN STARTXXXXXXXXXXXXXXXXX")
 		defer log.Debugf("XXXXXXXXXXXXXXXXXXLOCAL TASK RUN END  XXXXXXXXXXXXXXXXX")
@@ -58,4 +58,8 @@ func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
 		}
 
 	}, nil, nil)
+}
+
+func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
+	LocalTaskRunWithWorkers(task, proc, localTaskWorkerMan)
 }

--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -34,9 +34,12 @@ type CloudProviderSyncInfoTask struct {
 	taskman.STask
 }
 
+var syncLocalTaskWorkerMan *appsrv.SWorkerManager
+
 func InitCloudproviderSyncWorkers(count int) {
 	syncWorker := appsrv.NewWorkerManager("CloudProviderSyncInfoTaskWorkerManager", count, 512, true)
 	taskman.RegisterTaskAndWorker(CloudProviderSyncInfoTask{}, syncWorker)
+	syncLocalTaskWorkerMan = appsrv.NewWorkerManager("CloudProviderSyncLocalTaskWorkerManager", count, 512, false)
 }
 
 func getAction(params *jsonutils.JSONDict) string {
@@ -94,17 +97,32 @@ func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoComplete(ctx co
 	syncRange := self.GetSyncRange()
 
 	db.OpsLog.LogEvent(provider, db.ACT_SYNCING_HOST, "", self.UserCred)
+	self.SetStage("OnSyncCloudProviderInfoComplete", nil)
 
-	provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
-	provider.SyncCallSyncCloudproviderInterVpcNetwork(ctx, self.UserCred)
-
-	provider.CleanSchedCache()
-	self.SetStageComplete(ctx, nil)
-	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
-	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
+	taskman.LocalTaskRunWithWorkers(self, func() (jsonutils.JSONObject, error) {
+		provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
+		provider.SyncCallSyncCloudproviderInterVpcNetwork(ctx, self.UserCred)
+		return nil, nil
+	}, syncLocalTaskWorkerMan)
 }
 
 func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoCompleteFailed(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	log.Errorf("faild to sync provider quotas %s", body.String())
 	self.OnSyncCloudProviderPreInfoComplete(ctx, obj, body)
+}
+
+func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderInfoComplete(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	provider := obj.(*models.SCloudprovider)
+	provider.CleanSchedCache()
+	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
+	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderInfoCompleteFailed(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	provider := obj.(*models.SCloudprovider)
+	provider.CleanSchedCache()
+	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_FAILED, "", self.UserCred)
+	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, false)
+	self.SetStageFailed(ctx, nil)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

CloudProviderSyncInfoTask will local cloudprovider. Make locaktask run
time-consuming task can avoid holding locks for a long time.

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @ioito @zexi 