### PR TITLE
Automated cherry pick of #10906: fix(region): use special localtask to run time-consuming provider synchronization task

### DIFF
--- a/pkg/cloudcommon/db/taskman/localtaskworker.go
+++ b/pkg/cloudcommon/db/taskman/localtaskworker.go
@@ -37,8 +37,8 @@ func Error2TaskData(err error) jsonutils.JSONObject {
 	return errJson
 }
 
-func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
-	localTaskWorkerMan.Run(func() {
+func LocalTaskRunWithWorkers(task ITask, proc func() (jsonutils.JSONObject, error), wm *appsrv.SWorkerManager) {
+	wm.Run(func() {
 
 		log.Debugf("XXXXXXXXXXXXXXXXXXLOCAL TASK RUN STARTXXXXXXXXXXXXXXXXX")
 		defer log.Debugf("XXXXXXXXXXXXXXXXXXLOCAL TASK RUN END  XXXXXXXXXXXXXXXXX")
@@ -58,4 +58,8 @@ func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
 		}
 
 	}, nil, nil)
+}
+
+func LocalTaskRun(task ITask, proc func() (jsonutils.JSONObject, error)) {
+	LocalTaskRunWithWorkers(task, proc, localTaskWorkerMan)
 }

--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -34,9 +34,12 @@ type CloudProviderSyncInfoTask struct {
 	taskman.STask
 }
 
+var syncLocalTaskWorkerMan *appsrv.SWorkerManager
+
 func InitCloudproviderSyncWorkers(count int) {
 	syncWorker := appsrv.NewWorkerManager("CloudProviderSyncInfoTaskWorkerManager", count, 512, true)
 	taskman.RegisterTaskAndWorker(CloudProviderSyncInfoTask{}, syncWorker)
+	syncLocalTaskWorkerMan = appsrv.NewWorkerManager("CloudProviderSyncLocalTaskWorkerManager", count, 512, false)
 }
 
 func getAction(params *jsonutils.JSONDict) string {
@@ -94,16 +97,31 @@ func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoComplete(ctx co
 	syncRange := self.GetSyncRange()
 
 	db.OpsLog.LogEvent(provider, db.ACT_SYNCING_HOST, "", self.UserCred)
+	self.SetStage("OnSyncCloudProviderInfoComplete", nil)
 
-	provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
-
-	provider.CleanSchedCache()
-	self.SetStageComplete(ctx, nil)
-	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
-	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
+	taskman.LocalTaskRunWithWorkers(self, func() (jsonutils.JSONObject, error) {
+		provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
+		return nil, nil
+	}, syncLocalTaskWorkerMan)
 }
 
 func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderPreInfoCompleteFailed(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	log.Errorf("faild to sync provider quotas %s", body.String())
 	self.OnSyncCloudProviderPreInfoComplete(ctx, obj, body)
+}
+
+func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderInfoComplete(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	provider := obj.(*models.SCloudprovider)
+	provider.CleanSchedCache()
+	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_COMPLETE, "", self.UserCred)
+	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, true)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *CloudProviderSyncInfoTask) OnSyncCloudProviderInfoCompleteFailed(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	provider := obj.(*models.SCloudprovider)
+	provider.CleanSchedCache()
+	db.OpsLog.LogEvent(provider, db.ACT_SYNC_HOST_FAILED, "", self.UserCred)
+	logclient.AddActionLogWithStartable(self, provider, getAction(self.Params), body, self.UserCred, false)
+	self.SetStageFailed(ctx, nil)
 }


### PR DESCRIPTION
Cherry pick of #10906 on release/3.5.

#10906: fix(region): use special localtask to run time-consuming provider synchronization task