### PR TITLE
fix(monitor): alertpanel create fix; nodealert filterbyowner fix

### DIFF
--- a/pkg/monitor/models/alertdashboard.go
+++ b/pkg/monitor/models/alertdashboard.go
@@ -204,6 +204,7 @@ func (dash *SAlertDashBoard) getAttachPanels() ([]SAlertPanel, error) {
 	sq := AlertDashBoardPanelManager.Query(AlertDashBoardPanelManager.GetSlaveFieldName()).Equals(
 		AlertDashBoardPanelManager.GetMasterFieldName(), dash.Id).SubQuery()
 	panelQuery = panelQuery.In("id", sq)
+	panelQuery = panelQuery.Desc("created_at")
 	err := db.FetchModelObjects(AlertPanelManager, panelQuery, &panels)
 	if err != nil {
 		return panels, errors.Wrapf(err, "dashboard:%s get attach panels error", dash.Name)

--- a/pkg/monitor/models/alertpannel.go
+++ b/pkg/monitor/models/alertpannel.go
@@ -117,10 +117,10 @@ func (man *SAlertPanelManager) ValidateCreateData(
 		}
 	}
 
-	name, err := db.GenerateName(ctx, man, ownerId, data.Name)
-	if err != nil {
-		return data, err
-	}
+	//name, err := db.GenerateName(man, ownerId, data.Name)
+	//if err != nil {
+	//	return data, err
+	//}
 
 	alertCreateInput := man.toAlertCreateInput(data)
 	data.AlertCreateInput = alertCreateInput
@@ -129,8 +129,12 @@ func (man *SAlertPanelManager) ValidateCreateData(
 		data.Enabled = &enable
 	}
 
-	data.Name = name
+	//data.Name = name
 	return data, nil
+}
+
+func (man *SAlertPanelManager) HasName() bool {
+	return false
 }
 
 func (man *SAlertPanelManager) toAlertCreateInput(input monitor.AlertPanelCreateInput) monitor.AlertCreateInput {

--- a/pkg/monitor/models/nodealert.go
+++ b/pkg/monitor/models/nodealert.go
@@ -35,6 +35,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	merrors "yunion.io/x/onecloud/pkg/monitor/errors"
 	"yunion.io/x/onecloud/pkg/monitor/options"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
@@ -846,4 +847,9 @@ func (alert *SNodeAlert) CustomizeDelete(
 	ctx context.Context, userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	return alert.SV1Alert.CustomizeDelete(ctx, userCred, query, data)
+}
+
+func (m *SNodeAlertManager) FilterByOwner(q *sqlchemy.SQuery, userCred mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
+
+	return q
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.监控图表保存时取消重名检测，允许图表重名
2.虚拟机详情页设置报警时，不同视图下设置报警权限调整

https://bug.yunion.io/zentao/bug-view-7063.html

**是否需要 backport 到之前的 release 分支**:
- release/3.7

/cc @zexi 
/area monitor
