### PR TITLE
Correctly execute the ansible playbook with the specified private key

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks.go
@@ -186,10 +186,12 @@ func (apb *SAnsiblePlaybook) runPlaybook(ctx context.Context, userCred mcclient.
 
 	// init private key
 	pb := apb.Playbook.Copy()
-	if k, err := mcclient_modules.Sshkeypairs.FetchPrivateKey(ctx, userCred); err != nil {
-		return err
-	} else {
-		pb.PrivateKey = []byte(k)
+	if len(pb.PrivateKey) == 0 {
+		if k, err := mcclient_modules.Sshkeypairs.FetchPrivateKey(ctx, userCred); err != nil {
+			return err
+		} else {
+			pb.PrivateKey = []byte(k)
+		}
 	}
 	pb.OutputWriter(&ansiblePlaybookOutputWriter{apb})
 

--- a/pkg/ansibleserver/models/ansibleplaybooks.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks.go
@@ -25,6 +25,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/sqlchemy"
 
+	"yunion.io/x/onecloud/pkg/ansibleserver/options"
 	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/ansible"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -192,6 +193,10 @@ func (apb *SAnsiblePlaybook) runPlaybook(ctx context.Context, userCred mcclient.
 		} else {
 			pb.PrivateKey = []byte(k)
 		}
+	}
+	// init tmpdir clean policy
+	if options.Options.KeepTmpdir {
+		pb.CleanOnExit(false)
 	}
 	pb.OutputWriter(&ansiblePlaybookOutputWriter{apb})
 

--- a/pkg/ansibleserver/models/ansibleplaybooks_validator.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_validator.go
@@ -87,6 +87,10 @@ func (v *ValidatorAnsiblePlaybook) Validate(data *jsonutils.JSONDict) error {
 			}
 		}
 	}
+	// add LF for privateKey
+	if len(pb.PrivateKey) > 0 && pb.PrivateKey[len(pb.PrivateKey)-1] != 10 {
+		pb.PrivateKey = append(pb.PrivateKey, 10)
+	}
 	pbJson := jsonutils.Marshal(pb)
 	if serialized := pbJson.String(); len(serialized) > PlaybookMaxBytes {
 		return httperrors.NewBadRequestError("playbook too big, got %d bytes, exceeding %d",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- fix(ansibleserver): don't init privateKey for ansibleplaybook if it already have one
- feat(ansibleserver): respect keepTmpdir when running ansibleplaybook v1
- fix(ansibleserver): add LF for privateKey if not


- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area ansibleserver
/cc @swordqiu @zexi @yousong 