### PR TITLE
Automated cherry pick of #10934: fix(region): add all.servers.any_pool/all.hosts.any_pool metrics

### DIFF
--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -760,6 +760,7 @@ func hostUsage(
 
 	result := models.HostManager.TotalCount(userCred, scope, rangeObjs, "", "", hostTypes, resourceTypes, providers, brands, cloudEnv, enabled, isBaremetal)
 	count[prefix] = result.Count
+	count[fmt.Sprintf("%s.any_pool", prefix)] = result.Count
 	count[fmt.Sprintf("%s.memory", prefix)] = result.Memory
 	count[fmt.Sprintf("%s.memory.total", prefix)] = result.MemoryTotal
 	count[fmt.Sprintf("%s.cpu", prefix)] = result.CPU
@@ -814,6 +815,7 @@ func guestHypervisorsUsage(
 		includeSystem, pendingDelete, hostTypes, resourceTypes, providers, brands, cloudEnv, since)
 	count := make(map[string]interface{})
 	count[prefix] = guest.TotalGuestCount
+	count[fmt.Sprintf("%s.any_pool", prefix)] = guest.TotalGuestCount
 	count[fmt.Sprintf("%s.cpu", prefix)] = guest.TotalCpuCount
 	count[fmt.Sprintf("%s.memory", prefix)] = guest.TotalMemSize
 


### PR DESCRIPTION
Cherry pick of #10934 on release/3.6.

#10934: fix(region): add all.servers.any_pool/all.hosts.any_pool metrics