### PR TITLE
fix(baremetal,esxiagent): no cloudroot user initialized

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/drivers.go
+++ b/pkg/hostman/guestfs/fsdriver/drivers.go
@@ -57,5 +57,8 @@ func Init(initPrivatePrefixes []string, cloudrootDir string) error {
 	}
 	hostCpuArch = strings.TrimSpace(string(cpuArch))
 	cloudrootDirectory = cloudrootDir
+	if len(cloudrootDirectory) == 0 {
+		cloudrootDirectory = "/opt"
+	}
 	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：baremetal/esxiagent的cloudroot用户没有创建

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area baremeta-agent