### PR TITLE
Automated cherry pick of #10937: fix(baremetal,esxiagent): no cloudroot user initialized

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/drivers.go
+++ b/pkg/hostman/guestfs/fsdriver/drivers.go
@@ -57,5 +57,8 @@ func Init(initPrivatePrefixes []string, cloudrootDir string) error {
 	}
 	hostCpuArch = strings.TrimSpace(string(cpuArch))
 	cloudrootDirectory = cloudrootDir
+	if len(cloudrootDirectory) == 0 {
+		cloudrootDirectory = "/opt"
+	}
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #10937 on release/3.6.

#10937: fix(baremetal,esxiagent): no cloudroot user initialized