### PR TITLE
fix for creating proxy endpoint

### DIFF
--- a/pkg/cloudproxy/models/proxy_endpoints.go
+++ b/pkg/cloudproxy/models/proxy_endpoints.go
@@ -110,8 +110,8 @@ func (man *SProxyEndpointManager) PerformCreateFromServer(ctx context.Context, u
 		IntranetIpAddr: nic.IpAddr,
 	}
 	proxyendpoint.Name = name
-	proxyendpoint.DomainId = userCred.GetProjectDomainId()
-	proxyendpoint.ProjectId = userCred.GetProjectId()
+	proxyendpoint.DomainId = serverInfo.Server.DomainId
+	proxyendpoint.ProjectId = serverInfo.Server.ProjectId
 	if err := man.TableSpec().Insert(ctx, proxyendpoint); err != nil {
 		return nil, httperrors.NewServerError("database insertion error: %v", err)
 	}

--- a/pkg/compute/sshkeys/handler.go
+++ b/pkg/compute/sshkeys/handler.go
@@ -41,7 +41,7 @@ func AddSshKeysHandler(prefix string, app *appsrv.Application) {
 func adminSshKeysHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	publicOnly := false
 	userCred := auth.FetchUserCredential(ctx, policy.FilterPolicyCredential)
-	if !userCred.IsAllow(rbacutils.ScopeSystem, consts.GetServiceType(), "sshkeypairs", policy.PolicyActionGet) {
+	if !userCred.IsAllow(rbacutils.ScopeDomain, consts.GetServiceType(), "sshkeypairs", policy.PolicyActionGet) {
 		publicOnly = true
 	}
 	params := appctx.AppContextParams(ctx)

--- a/pkg/mcclient/models/base.go
+++ b/pkg/mcclient/models/base.go
@@ -77,6 +77,7 @@ type EnabledStatusStandaloneResource struct {
 type VirtualResource struct {
 	StatusStandaloneResource
 
+	DomainId         string
 	ProjectId        string
 	IsSystem         bool
 	PendingDeletedAt time.Time


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

问题复述：
1. 从虚拟机创建PE，希望PE的项目和虚拟机保持一致
2. 域管理员从虚拟机创建PE，获取serverInfo时拿不到ssh private key

问题修复：
- fix(cloudproxy): keep the proxy endpoint project and server consistent
- fix(region): allow domain admin to obtain ssh private keys

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region cloudproxy
/cc @yousong @zexi 