### PR TITLE
Bugfix/yousong cloudproxy wait on error

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -898,6 +898,10 @@ func getModelItemDetails(manager IModelManager, item IModel, ctx context.Context
 	}
 }
 
+func GetItemDetails(manager IModelManager, item IModel, ctx context.Context, userCred mcclient.TokenCredential) (jsonutils.JSONObject, error) {
+	return getItemDetails(manager, item, ctx, userCred, nil)
+}
+
 func getItemDetails(manager IModelManager, item IModel, ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	metaFields, excludeFields := GetDetailFields(manager, userCred)
 	fieldFilter := jsonutils.GetQueryStringArray(query, "field")

--- a/pkg/cloudproxy/agent/ssh/client.go
+++ b/pkg/cloudproxy/agent/ssh/client.go
@@ -186,10 +186,11 @@ func (c *Client) runClientState(ctx context.Context, sshClientC chan *ssh.Client
 		default:
 		}
 
+		cc := c.cc
 		tmoCtx, _ := context.WithTimeout(ctx, 31*time.Second)
-		sshc, err := c.cc.ConnectContext(tmoCtx)
+		sshc, err := cc.ConnectContext(tmoCtx)
 		if err != nil {
-			log.Errorf("ssh connect: %v", err)
+			log.Errorf("ssh connect: %s@%s, port %d: %v", cc.Username, cc.Host, cc.Port, err)
 			waitTmo := time.NewTimer(13 * time.Second)
 			select {
 			case <-ctx.Done():

--- a/pkg/cloudproxy/agent/ssh/client.go
+++ b/pkg/cloudproxy/agent/ssh/client.go
@@ -190,6 +190,12 @@ func (c *Client) runClientState(ctx context.Context, sshClientC chan *ssh.Client
 		sshc, err := c.cc.ConnectContext(tmoCtx)
 		if err != nil {
 			log.Errorf("ssh connect: %v", err)
+			waitTmo := time.NewTimer(13 * time.Second)
+			select {
+			case <-ctx.Done():
+				return
+			case <-waitTmo.C:
+			}
 			continue
 		}
 

--- a/pkg/cloudproxy/models/forwards.go
+++ b/pkg/cloudproxy/models/forwards.go
@@ -256,7 +256,11 @@ func (man *SForwardManager) PerformCreateFromServer(ctx context.Context, userCre
 		data, err = man.validatePortReq(ctx, typ, -1, agentId, epId, data)
 	}
 
-	forward := &SForward{}
+	forwardObj, err := db.NewModelObject(man)
+	if err != nil {
+		return nil, httperrors.NewGeneralError(err)
+	}
+	forward := forwardObj.(*SForward)
 	if err := data.Unmarshal(forward); err != nil {
 		return nil, httperrors.NewServerError("unmarshal create params: %v", err)
 	}
@@ -267,7 +271,7 @@ func (man *SForwardManager) PerformCreateFromServer(ctx context.Context, userCre
 		return nil, httperrors.NewServerError("database insertion error: %v", err)
 	}
 
-	return jsonutils.Marshal(forward), nil
+	return db.GetItemDetails(man, forward, ctx, userCred)
 }
 
 func (man *SForwardManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {

--- a/pkg/compute/models/guest_sshable.go
+++ b/pkg/compute/models/guest_sshable.go
@@ -207,10 +207,11 @@ func (guest *SGuest) sshableTryEach(
 		res, err := cloudproxy_module.Forwards.PerformClassAction(sess, "create-from-server", fwdCreateParams)
 		if err == nil {
 			var fwd cloudproxy_api.ForwardDetails
-			if err := res.Unmarshal(&fwd); err == nil {
-				if ok := guest.sshableTryForward(ctx, tryData, &fwd); ok {
-					return nil
-				}
+			if err := res.Unmarshal(&fwd); err != nil {
+				log.Errorf("unmarshal fwd details: %q", res.String())
+			}
+			if ok := guest.sshableTryForward(ctx, tryData, &fwd); ok {
+				return nil
 			}
 		} else {
 			var reason string


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
db: add GetItemDetails
cloudproxy: forwards: show details for fwd returned from create-from-server
cloudproxy: agent: wait a while on connect error
cloudproxy: agent: more verbose log for ssh connect failure
guests: sshable: log error should unmarshal fail
guests: sshable: wait and retry for newly created forward
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.7

/area region
/area cloudproxy
/cc @rainzm 
/cc @zexi 
