### PR TITLE
feat(monitor): add storage monitor metric

### DIFF
--- a/pkg/apis/monitor/alertquery_const.go
+++ b/pkg/apis/monitor/alertquery_const.go
@@ -144,4 +144,19 @@ var (
 		"domain_id":      "id",
 		"project_domain": "name",
 	}
+
+	StorageTags = map[string]string{
+		"id":             "storage_id",
+		"name":           "storage_name",
+		"zone":           "zone",
+		"zone_id":        "zone_id",
+		"zone_ext_id":    "zone_ext_id",
+		"status":         "status",
+		"cloudregion":    "cloudregion",
+		"cloudregion_id": "cloudregion_id",
+		"region_ext_id":  "region_ext_id",
+		"brand":          "brand",
+		"domain_id":      "domain_id",
+		"project_domain": "project_domain",
+	}
 )

--- a/pkg/apis/monitor/metric.go
+++ b/pkg/apis/monitor/metric.go
@@ -12,6 +12,7 @@ const (
 	METRIC_RES_TYPE_AGENT        = "agent"
 	METRIC_RES_TYPE_TENANT       = "tenant"
 	METRIC_RES_TYPE_DOMAIN       = "domain"
+	METRIC_RES_TYPE_STORAGE      = "storage"
 
 	METRIC_UNIT_PERCENT = "%"
 	METRIC_UNIT_BPS     = "bps"
@@ -22,6 +23,7 @@ const (
 	METRIC_UNIT_MS      = "ms"
 	METRIC_UNIT_BYTE    = "byte"
 	METRIC_UNIT_RMB     = "RMB"
+	METRIC_UNIT_MB      = "Mb"
 
 	METRIC_DATABASE_TELE  = "telegraf"
 	METRIC_DATABASE_METER = "meter_db"
@@ -40,6 +42,7 @@ var (
 		METRIC_RES_TYPE_RDS:          4,
 		METRIC_RES_TYPE_REDIS:        5,
 		METRIC_RES_TYPE_CLOUDACCOUNT: 6,
+		METRIC_RES_TYPE_STORAGE:      7,
 	}
 )
 

--- a/pkg/apis/monitor/unifiedmonitor_const.go
+++ b/pkg/apis/monitor/unifiedmonitor_const.go
@@ -13,12 +13,13 @@ var (
 	}
 
 	MEASUREMENT_TAG_KEYWORD = map[string]string{
-		"host":         "host",
-		"guest":        "vm_name",
-		"redis":        "redis_name",
-		"rds":          "rds_name",
-		"oss":          "oss_name",
-		"cloudaccount": "cloudaccount_name",
+		METRIC_RES_TYPE_HOST:         "host",
+		METRIC_RES_TYPE_GUEST:        "vm_name",
+		METRIC_RES_TYPE_REDIS:        "redis_name",
+		METRIC_RES_TYPE_RDS:          "rds_name",
+		METRIC_RES_TYPE_OSS:          "oss_name",
+		METRIC_RES_TYPE_CLOUDACCOUNT: "cloudaccount_name",
+		METRIC_RES_TYPE_STORAGE:      "storage_name",
 	}
 	MEASUREMENT_TAG_ID = map[string]string{
 		METRIC_RES_TYPE_HOST:         "host_id",
@@ -30,6 +31,7 @@ var (
 		METRIC_RES_TYPE_CLOUDACCOUNT: "cloudaccount_id",
 		METRIC_RES_TYPE_TENANT:       "tenant_id",
 		METRIC_RES_TYPE_DOMAIN:       "domain_id",
+		METRIC_RES_TYPE_STORAGE:      "storage_id",
 	}
 	AlertReduceFunc = map[string]string{
 		"avg":          "average value",

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -564,6 +564,9 @@ func (c *QueryCondition) getOnecloudResources() ([]jsonutils.JSONObject, error) 
 		allResources, err = ListAllResources(&mc_mds.Projects, query)
 	case monitor.METRIC_RES_TYPE_DOMAIN:
 		allResources, err = ListAllResources(&mc_mds.Domains, query)
+	case monitor.METRIC_RES_TYPE_STORAGE:
+		query.Remove("status")
+		allResources, err = ListAllResources(&mc_mds.Storages, query)
 	default:
 		query := jsonutils.NewDict()
 		query.Set("brand", jsonutils.NewString(hostconsts.TELEGRAF_TAG_ONECLOUD_BRAND))
@@ -732,6 +735,8 @@ func (c *QueryCondition) getTagKeyRelationMap() map[string]string {
 		relationMap = monitor.TenantTags
 	case monitor.METRIC_RES_TYPE_DOMAIN:
 		relationMap = monitor.DomainTags
+	case monitor.METRIC_RES_TYPE_STORAGE:
+		relationMap = monitor.StorageTags
 	default:
 		relationMap = monitor.HostTags
 	}

--- a/pkg/monitor/dbinit/metric_dbinit.go
+++ b/pkg/monitor/dbinit/metric_dbinit.go
@@ -339,4 +339,9 @@ func init() {
 			newMetricFieldCreateInput("drop_out", "The total number of transmission packets dropped by the network interface", monitor.METRIC_UNIT_COUNT, 8),
 		})
 
+	RegistryMetricCreateInput("storage", "Storage usage",
+		monitor.METRIC_RES_TYPE_STORAGE, monitor.METRIC_DATABASE_TELE, 1, []monitor.MetricFieldCreateInput{
+			newMetricFieldCreateInput("usage_active", "Storage utilization rate", monitor.METRIC_UNIT_PERCENT, 1),
+			newMetricFieldCreateInput("free", "Free storage", monitor.METRIC_UNIT_MB, 2),
+		})
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.增加块存储storage监控信息：
  1）增加对应翻译信息
  2）监控信息和modules.Strorages接口进行交集取值
  3）返回信息处理

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.6
- release/3.7

/cc @zexi 
/area monitor 
/hold 
