### PR TITLE
maintain compatibility with previous webhooks

### DIFF
--- a/pkg/cloudcommon/notifyclient/notify.go
+++ b/pkg/cloudcommon/notifyclient/notify.go
@@ -240,6 +240,9 @@ func (t *eventTask) Run() {
 }
 
 func EventNotify(ctx context.Context, userCred mcclient.TokenCredential, ep SEventNotifyParam) {
+	// disable EventNotify for now
+	return
+
 	ret, err := db.FetchCustomizeColumns(ep.Obj.GetModelManager(), ctx, userCred, jsonutils.NewDict(), []interface{}{ep.Obj}, stringutils2.SSortedStrings{}, false)
 	if err != nil {
 		log.Errorf("unable to FetchCustomizeColumns: %v", err)

--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -159,7 +159,7 @@ func (self *GuestCreateTask) OnDeployGuestDescComplete(ctx context.Context, obj 
 }
 
 func (self *GuestCreateTask) notifyServerCreated(ctx context.Context, guest *models.SGuest) {
-	// notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionCreate)
+	notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionCreate)
 	guest.EventNotify(ctx, self.UserCred, notifyclient.ActionCreate)
 }
 

--- a/pkg/compute/tasks/guest_rebuild_root_task.go
+++ b/pkg/compute/tasks/guest_rebuild_root_task.go
@@ -175,7 +175,7 @@ func (self *GuestRebuildRootTask) OnRebuildAllDisksComplete(ctx context.Context,
 		}
 	}
 	db.OpsLog.LogEvent(guest, db.ACT_REBUILD_ROOT, "", self.UserCred)
-	// notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionRebuildRoot)
+	notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionRebuildRoot)
 	guest.EventNotify(ctx, self.UserCred, notifyclient.ActionRebuildRoot)
 	self.SetStage("OnSyncStatusComplete", nil)
 	guest.StartSyncstatus(ctx, self.UserCred, self.GetTaskId())


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

3.7 的后端，webhook功能容纳到了消息订阅里面，但是前端还没开启消息订阅功能，所以
1. 后端禁用消息订阅
2. 对旧的webook保持兼容

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @zexi 