### PR TITLE
Automated cherry pick of #11050: fix(ansibleserver): correct playbook path and role path

### DIFF
--- a/pkg/util/ansiblev2/playbook_session.go
+++ b/pkg/util/ansiblev2/playbook_session.go
@@ -84,7 +84,7 @@ func (r runnable) Run(ctx context.Context) (err error) {
 	// write out playbook
 	playbook := r.GetPlaybookPath()
 	if len(playbook) == 0 {
-		playbook := filepath.Join(tmpdir, "playbook")
+		playbook = filepath.Join(tmpdir, "playbook")
 		err = ioutil.WriteFile(playbook, []byte(r.GetPlaybook()), os.FileMode(0600))
 		if err != nil {
 			err = errors.Wrapf(err, "writing playbook %s", playbook)


### PR DESCRIPTION
Cherry pick of #11050 on release/3.7.

#11050: fix(ansibleserver): correct playbook path and role path