### PR TITLE
Automated cherry pick of #11095: fix(region): use the previous method for guest notification instead of message subscription

### DIFF
--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/notifyclient"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/notify"
 	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 )
@@ -160,7 +161,12 @@ func (self *GuestCreateTask) OnDeployGuestDescComplete(ctx context.Context, obj 
 
 func (self *GuestCreateTask) notifyServerCreated(ctx context.Context, guest *models.SGuest) {
 	notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionCreate)
-	guest.EventNotify(ctx, self.UserCred, notifyclient.ActionCreate)
+	guest.NotifyServerEvent(
+		ctx, self.UserCred, notifyclient.SERVER_CREATED,
+		notify.NotifyPriorityImportant, true, nil, false,
+	)
+	guest.NotifyAdminServerEvent(ctx, notifyclient.SERVER_CREATED_ADMIN, notify.NotifyPriorityImportant)
+	// guest.EventNotify(ctx, self.UserCred, notifyclient.ActionCreate)
 }
 
 func (self *GuestCreateTask) OnDeployGuestDescCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/guest_delete_task.go
+++ b/pkg/compute/tasks/guest_delete_task.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/notifyclient"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/compute/options"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/notify"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
@@ -353,5 +354,14 @@ func (self *GuestDeleteTask) DeleteGuest(ctx context.Context, guest *models.SGue
 }
 
 func (self *GuestDeleteTask) NotifyServerDeleted(ctx context.Context, guest *models.SGuest) {
-	guest.EventNotify(ctx, self.UserCred, notifyclient.ActionPendingDelete)
+	notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionPendingDelete)
+	guest.NotifyServerEvent(
+		ctx,
+		self.UserCred,
+		notifyclient.SERVER_DELETED,
+		notify.NotifyPriorityImportant,
+		false, nil, false,
+	)
+	guest.NotifyAdminServerEvent(ctx, notifyclient.SERVER_DELETED_ADMIN, notify.NotifyPriorityImportant)
+	// guest.EventNotify(ctx, self.UserCred, notifyclient.ActionPendingDelete)
 }

--- a/pkg/compute/tasks/guest_rebuild_root_task.go
+++ b/pkg/compute/tasks/guest_rebuild_root_task.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/notifyclient"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/mcclient/modules/notify"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
@@ -176,7 +177,14 @@ func (self *GuestRebuildRootTask) OnRebuildAllDisksComplete(ctx context.Context,
 	}
 	db.OpsLog.LogEvent(guest, db.ACT_REBUILD_ROOT, "", self.UserCred)
 	notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionRebuildRoot)
-	guest.EventNotify(ctx, self.UserCred, notifyclient.ActionRebuildRoot)
+	guest.NotifyServerEvent(
+		ctx,
+		self.UserCred,
+		notifyclient.SERVER_REBUILD_ROOT,
+		notify.NotifyPriorityImportant,
+		true, nil, false,
+	)
+	// guest.EventNotify(ctx, self.UserCred, notifyclient.ActionRebuildRoot)
 	self.SetStage("OnSyncStatusComplete", nil)
 	guest.StartSyncstatus(ctx, self.UserCred, self.GetTaskId())
 }


### PR DESCRIPTION
Cherry pick of #11095 on release/3.7.

#11095: fix(region): use the previous method for guest notification instead of message subscription