### PR TITLE
fix(esxiagent): make the copied disk type as thin

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -820,10 +820,24 @@ func (self *SHost) addDisks(ctx context.Context, dc *SDatacenter, ds *SDatastore
 				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
 			}
 			newImagePath := fmt.Sprintf("[%s] %s/%s.vmdk", ds.GetRelName(), uuid, uuid)
-			fm := ds.getDatastoreObj().NewFileManager(dc.getObjectDatacenter(), true)
-			err = fm.Copy(ctx, imagePath, newImagePath)
+
+			dm := object.NewVirtualDiskManager(self.manager.client.Client)
+			spec := &types.VirtualDiskSpec{
+				DiskType: "thin",
+			}
+			switch disk.Driver {
+			case "", "scsi", "pvscsi":
+				spec.AdapterType = "lsiLogic"
+			default:
+				spec.AdapterType = "ide"
+			}
+			task, err := dm.CopyVirtualDisk(self.manager.context, imagePath, self.datacenter.getDcObj(), newImagePath, self.datacenter.getDcObj(), spec, true)
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to copy system disk")
+				return nil, errors.Wrap(err, "unable to CopyVirtualDisk")
+			}
+			err = task.Wait(self.manager.context)
+			if err != nil {
+				return nil, errors.Wrap(err, "waith CopyVirtualDiskTask")
 			}
 			imagePath = newImagePath
 			rootDiskSizeMb = size


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

使用公共镜像创建出来的磁盘默认不是精简制备的，其原因是 copy 磁盘的时候默认是预分配类型，需要特殊指定为thin

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent
/cc @swordqiu @zexi 