### PR TITLE
fix(region): aws sync disk missing image id fix

### DIFF
--- a/pkg/multicloud/aws/disk.go
+++ b/pkg/multicloud/aws/disk.go
@@ -333,6 +333,7 @@ func (self *SRegion) GetDisks(instanceId string, zoneId string, storageType stri
 
 				if disk.Device == instance.RootDeviceName {
 					disk.Type = api.DISK_TYPE_SYS
+					disk.ImageId = instance.ImageId
 				} else {
 					disk.Type = api.DISK_TYPE_DATA
 				}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* aws sync disk missing image id fix

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6


/area region
/cc @zexi @ioito 