### PR TITLE
Automated cherry pick of #11112: fix(region): aws sync disk missing image id fix

### DIFF
--- a/pkg/multicloud/aws/disk.go
+++ b/pkg/multicloud/aws/disk.go
@@ -333,6 +333,7 @@ func (self *SRegion) GetDisks(instanceId string, zoneId string, storageType stri
 
 				if disk.Device == instance.RootDeviceName {
 					disk.Type = api.DISK_TYPE_SYS
+					disk.ImageId = instance.ImageId
 				} else {
 					disk.Type = api.DISK_TYPE_DATA
 				}


### PR DESCRIPTION
Cherry pick of #11112 on release/3.7.

#11112: fix(region): aws sync disk missing image id fix