### PR TITLE
Automated cherry pick of #11121: fix(esxiagent): execute deploy operation by default in AgentDeployGuest

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -195,7 +195,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 	dataDict := data.(*jsonutils.JSONDict)
 	action, _ := dataDict.GetString("action")
 	var (
-		needDeploy bool
+		needDeploy = true
 		err        error
 	)
 	if action == "create" {


### PR DESCRIPTION
Cherry pick of #11121 on release/3.6.

#11121: fix(esxiagent): execute deploy operation by default in AgentDeployGuest