### PR TITLE
Automated cherry pick of #11126: fix(region): check whether the disks of the instance snapshot is empty when creating vm

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1087,7 +1087,11 @@ func parseInstanceSnapshot(input *api.ServerCreateInput) (*api.ServerCreateInput
 	if isp.Status != api.INSTANCE_SNAPSHOT_READY {
 		return nil, httperrors.NewBadRequestError("Instance snapshot not ready")
 	}
-	return isp.ToInstanceCreateInput(input)
+	input, err = isp.ToInstanceCreateInput(input)
+	if len(input.Disks) == 0 {
+		return nil, httperrors.NewInputParameterError("there are no disks in this instance snapshot, try another one")
+	}
+	return input, nil
 }
 
 func (manager *SGuestManager) validateCreateData(


### PR DESCRIPTION
Cherry pick of #11126 on release/3.5.

#11126: fix(region): check whether the disks of the instance snapshot is empty when creating vm