### PR TITLE
fix: get apigateway auth/regions with error of illegal mix of collations

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -141,7 +141,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 	if options.Options.ReturnFullDomainList {
 		filters := jsonutils.NewDict()
 		if len(currentDomain) > 0 {
-			filters.Add(jsonutils.NewString(currentDomain), "id")
+			filters.Add(jsonutils.NewString(currentDomain), "name")
 		}
 		filters.Add(jsonutils.NewInt(1000), "limit")
 		result, e := modules.Domains.List(s, filters)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: apigateway report illegal of mix of collations if domain name is CHS

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.7
- release/3.6
- release/3.5

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
