### PR TITLE
Automated cherry pick of #11245: fix: get apigateway auth/regions with error of illegal mix of collations

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -141,7 +141,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 	if options.Options.ReturnFullDomainList {
 		filters := jsonutils.NewDict()
 		if len(currentDomain) > 0 {
-			filters.Add(jsonutils.NewString(currentDomain), "id")
+			filters.Add(jsonutils.NewString(currentDomain), "name")
 		}
 		filters.Add(jsonutils.NewInt(1000), "limit")
 		result, e := modules.Domains.List(s, filters)


### PR DESCRIPTION
Cherry pick of #11245 on release/3.7.

#11245: fix: get apigateway auth/regions with error of illegal mix of collations