### PR TITLE
fix(region): lbcert cache clean duplicate data fix

### DIFF
--- a/pkg/compute/models/loadbalancercachedcertificates.go
+++ b/pkg/compute/models/loadbalancercachedcertificates.go
@@ -587,7 +587,7 @@ func (manager *SCachedLoadbalancerCertificateManager) ListItemExportKeys(ctx con
 }
 
 func (man *SCachedLoadbalancerCertificateManager) InitializeData() error {
-	certs := man.Query().SubQuery()
+	certs := man.Query().IsFalse("pending_deleted").SubQuery()
 	sq := certs.Query(certs.Field("id"), certs.Field("external_id"), sqlchemy.COUNT("external_id").Label("total"))
 	sq2 := sq.GroupBy("external_id").SubQuery()
 	sq3 := sq2.Query(sq2.Field("external_id")).GT("total", 1).SubQuery()


### PR DESCRIPTION
**What this PR does / why we need it**:
* lbcert cache clean duplicate data fix
* 
**Does this PR need to be backport to the previous release branch?**:
If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

/area region
/cc @yousong @zexi 