### PR TITLE
Automated cherry pick of #11253: fix(region): lbcert cache clean duplicate data fix

### DIFF
--- a/pkg/compute/models/loadbalancercachedcertificates.go
+++ b/pkg/compute/models/loadbalancercachedcertificates.go
@@ -584,7 +584,7 @@ func (manager *SCachedLoadbalancerCertificateManager) ListItemExportKeys(ctx con
 }
 
 func (man *SCachedLoadbalancerCertificateManager) InitializeData() error {
-	certs := man.Query().SubQuery()
+	certs := man.Query().IsFalse("pending_deleted").SubQuery()
 	sq := certs.Query(certs.Field("id"), certs.Field("external_id"), sqlchemy.COUNT("external_id").Label("total"))
 	sq2 := sq.GroupBy("external_id").SubQuery()
 	sq3 := sq2.Query(sq2.Field("external_id")).GT("total", 1).SubQuery()


### PR DESCRIPTION
Cherry pick of #11253 on release/3.6.

#11253: fix(region): lbcert cache clean duplicate data fix